### PR TITLE
amended preg_match bug in the UndefinedLocalVariable rule

### DIFF
--- a/src/Rules/UndefinedLocalVariable.php
+++ b/src/Rules/UndefinedLocalVariable.php
@@ -173,7 +173,7 @@ class UndefinedLocalVariable extends AbstractLocalVariable implements FunctionAw
 
         foreach ($this->nodes as $variable) {
             $parent = $variable->getParent()->getParent();
-            if ($parent->isInstanceOf('FunctionPostfix') && in_array($parent->getImage(), ['preg_match', 'preg_match_all'])) {
+            if ($parent->isInstanceOf('FunctionPostfix') && in_array($this->getFunctionShortName($parent->getImage()), ['preg_match', 'preg_match_all'])) {
                 $children = $parent->findChildrenOfType('Variable');
                 $numberOfChildren = count($children);
                 $lastParameter = array_pop($children);
@@ -183,6 +183,20 @@ class UndefinedLocalVariable extends AbstractLocalVariable implements FunctionAw
                 }
             }
         }
+    }
+
+    /**
+     * @param string $functionName
+     * @return string
+     */
+    private function getFunctionShortName($functionName)
+    {
+        $lastSlashPosition = strrpos($functionName, '\\');
+        if ($lastSlashPosition === false)
+        {
+            return $functionName;
+        }
+        return substr($functionName, $lastSlashPosition + 1);
     }
 
     /**

--- a/test/TestUndefinedLocalVariable.php
+++ b/test/TestUndefinedLocalVariable.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Testing;
+
 class TestUndefinedLocalVariable
 {
     public $whatever = [];


### PR DESCRIPTION
The system had trouble matching the function names when the functions where used in a files inside a namespace.
